### PR TITLE
#55 Issue de envio de e-mail na inscrição

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,14 @@
 			<version>2.3.2.Final</version>
 			<scope>test</scope>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-email</artifactId>
+			<version>1.3.2</version>
+		</dependency>
+		
+		
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/jugvale/call4papers/model/config/RemetentePadraoDeEMailConfig.java
+++ b/src/main/java/org/jugvale/call4papers/model/config/RemetentePadraoDeEMailConfig.java
@@ -1,0 +1,77 @@
+/**
+ * 
+ */
+package org.jugvale.call4papers.model.config;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import javax.inject.Singleton;
+
+
+/**
+ * Classe que representa os atributos da configuração do remetente padrão de e-mail do sistema.
+ * @author daniel
+ *
+ */
+@Singleton
+public class RemetentePadraoDeEMailConfig {
+	
+	private String email;
+	private String senha;
+	private String hostSmtp;
+	private Integer porta;
+	private Boolean tlsHabilitado;
+	
+	public RemetentePadraoDeEMailConfig(){
+		carregarInformacoesDoPropeties();
+	}
+
+	/**
+	 * Carrega as informações do email do property
+	 */
+	private void carregarInformacoesDoPropeties() {
+		Properties emailProperties = new Properties();		
+		String propertyName = "email.properties";		
+		InputStream emailStream = getClass().getClassLoader().getResourceAsStream(propertyName);
+		try {
+			emailProperties.load(emailStream);		
+			this.email = emailProperties.getProperty("remetente");
+			this.senha = emailProperties.getProperty("senha");
+			this.hostSmtp = emailProperties.getProperty("hostSmtp");
+			this.porta = Integer.parseInt(emailProperties.getProperty("porta"));
+			this.tlsHabilitado = emailProperties.getProperty("tlsHabilitado").equals("sim") ? true : false;
+		} catch (IOException e) {
+			//Tratamento de erro feito provisório
+			System.err.println("Falha na leitura do arquivo email.properties");
+		} catch (Exception e){
+			//Tratamento de erro feito provisório
+			System.err.println("Falha ao carregar informações do e-mail");
+		}
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public String getSenha() {
+		return senha;
+	}
+
+	public String getHostSmtp() {
+		return hostSmtp;
+	}	
+
+	public Integer getPorta() {
+		return porta;
+	}
+
+	public Boolean getTlsHabilitado() {
+		return tlsHabilitado;
+	}
+
+}

--- a/src/main/java/org/jugvale/call4papers/rest/impl/InscricaoResourceImpl.java
+++ b/src/main/java/org/jugvale/call4papers/rest/impl/InscricaoResourceImpl.java
@@ -2,16 +2,21 @@ package org.jugvale.call4papers.rest.impl;
 
 import static org.jugvale.call4papers.rest.utils.RESTUtils.lanca404SeNulo;
 
+import java.text.MessageFormat;
+
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 
+import org.apache.commons.mail.SimpleEmail;
+import org.jugvale.call4papers.model.config.RemetentePadraoDeEMailConfig;
 import org.jugvale.call4papers.model.impl.Evento;
 import org.jugvale.call4papers.model.impl.Inscricao;
 import org.jugvale.call4papers.model.impl.Participante;
 import org.jugvale.call4papers.rest.InscricaoResource;
+import org.jugvale.call4papers.sender.EmailSender;
 import org.jugvale.call4papers.service.impl.EventoService;
 import org.jugvale.call4papers.service.impl.ParticipanteService;
 
@@ -23,6 +28,12 @@ public class InscricaoResourceImpl implements InscricaoResource {
 
 	@Inject
 	ParticipanteService participanteService;
+	
+	@Inject
+	EmailSender emailSender;
+	
+	@Inject
+	RemetentePadraoDeEMailConfig configuracaoDeEnvioDeEMail;
 
 	@Override
 	public Response inscrever(long eventoId, Participante participante) {
@@ -38,7 +49,8 @@ public class InscricaoResourceImpl implements InscricaoResource {
 		if (partipanteExistente != null) {
 			participante.setId(partipanteExistente.getId());
 		} else {
-			participanteService.salvar(participante);
+			participanteService.salvar(participante);		
+		
 		}
 		Inscricao inscricao = eventoService
 				.buscaInscricao(evento, participante);
@@ -48,10 +60,52 @@ public class InscricaoResourceImpl implements InscricaoResource {
 			inscricao = eventoService.inscreverParticipante(evento,
 					participante);
 			rb = Response.ok();
-			System.out.println("Participante com e-mail "
-					+ participante.getEmail() + " inscrito.");
+			enviarEMail(evento, participante);		
+			
 		}
 		return rb.entity(inscricao).build();
+	}
+
+	/**
+	 * Envia o email para o participante de confirmação do registro em um determinado evento,
+	 * este envio é feito em uma Thread paralela para evitar onerar a resposta ao usuario por causa de atrasos no envio do e-mail. 
+	 * @param evento Evento em que foi inscrito
+	 * @param participante Participante inscrito
+	 */
+	private void enviarEMail(Evento evento, Participante participante) {
+		String remetentePadraoDoSistema = configuracaoDeEnvioDeEMail.getEmail();
+		String participanteInscrito = participante.getEmail();
+		String inscricaoNoEvento = gerarAssuntoDeConfirmacaoDeEmail(evento);
+		String mensagemDeConfirmacaoDaInscricao = gerarMensagemDeConfirmacaoDeEmail(evento, participante);
+		
+		new Thread(new Runnable() {
+			public void run() {
+				emailSender.criarEmail().de(remetentePadraoDoSistema).para(participanteInscrito).
+					tratandoDo(inscricaoNoEvento).comA(mensagemDeConfirmacaoDaInscricao).paraEnviar();
+			}
+		}).start();
+	}
+
+	/**
+	 * Gera o assunto confirmando que o participante está inscrito no evento
+	 * @param evento
+	 * @return
+	 */
+	private String gerarAssuntoDeConfirmacaoDeEmail(Evento evento) {
+		return MessageFormat.format("Você está inscrito no evento {0}", evento.getNome());
+	}
+
+	/**
+	 * Gera a mensagem confirmando que o participante está inscrito no evento
+	 * @param evento
+	 * @param participante
+	 * @return
+	 */
+	private String gerarMensagemDeConfirmacaoDeEmail(Evento evento,
+			Participante participante) {
+		return MessageFormat.format(
+		"Parabéns {0}, sua inscrição no evento {1} que ocorrerá no dia {2} no local {3} está confirmada.\n Contamos com a sua participação.",
+		participante.getNome(), evento.getNome(), evento.getDataInicio(), evento.getLocal());
 	}
 
 }

--- a/src/main/java/org/jugvale/call4papers/sender/EmailSender.java
+++ b/src/main/java/org/jugvale/call4papers/sender/EmailSender.java
@@ -1,0 +1,41 @@
+/**
+ * 
+ */
+package org.jugvale.call4papers.sender;
+
+import java.util.Collection;
+
+/**
+ * Interface para abstração de envio de email.
+ * @author Daniel
+ *
+ */
+public interface EmailSender {		
+	
+	public static final String SUCESSO = "1"; 
+	
+	public DeRemetente criarEmail();	
+	
+	public interface DeRemetente{
+		public ParaDestinatario de(String remetente);
+	}	
+	
+	public interface ParaDestinatario{
+		public TratandoDoAssunto para(String destinatario);
+		
+		public TratandoDoAssunto para(Collection<String> destinatarios);
+	}	
+	
+	public interface TratandoDoAssunto{
+		public ComAMensagem tratandoDo(String assunto);
+	}	
+	
+	public interface ComAMensagem{
+		public ParaEnviar comA(String mensagem);
+	}	
+	
+	public interface ParaEnviar{
+		public String paraEnviar();
+	}	
+
+}

--- a/src/main/java/org/jugvale/call4papers/sender/impl/ApacheEmailSender.java
+++ b/src/main/java/org/jugvale/call4papers/sender/impl/ApacheEmailSender.java
@@ -1,0 +1,98 @@
+/**
+ * 
+ */
+package org.jugvale.call4papers.sender.impl;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import javax.inject.Inject;
+
+import org.apache.commons.mail.SimpleEmail;
+import org.jugvale.call4papers.model.config.RemetentePadraoDeEMailConfig;
+import org.jugvale.call4papers.sender.EmailSender;
+
+/**
+ * 
+ * Implementação da interface {@link EmailSender}, enviando e-mails utilizando a API ApacheCommons para o envio de e-mail.
+ * Caso outroa tecnologia vá ser usada, esse cara pode até ser abstraido na parte que não envolve a tecnologia especifica que sera utilzada.
+ * @author Daniel
+ *
+ */
+public class ApacheEmailSender implements EmailSender {
+	
+	@Inject
+	RemetentePadraoDeEMailConfig configuracaoDeEnvioDeEMail;
+
+	private class Email implements EmailSender.DeRemetente, EmailSender.ParaDestinatario, EmailSender.TratandoDoAssunto, EmailSender.ComAMensagem, EmailSender.ParaEnviar{
+		
+		private String remetente;
+		private Collection<String> destinatarios;
+		private String assunto;
+		private String mensagem;
+		
+		
+		@Override
+		public String paraEnviar() {	
+			
+			try{
+				SimpleEmail email = new SimpleEmail();
+				email.setAuthentication(configuracaoDeEnvioDeEMail.getEmail(), configuracaoDeEnvioDeEMail.getSenha());
+				email.setHostName(configuracaoDeEnvioDeEMail.getHostSmtp());
+				email.setSmtpPort(configuracaoDeEnvioDeEMail.getPorta());	
+				email.setStartTLSEnabled(configuracaoDeEnvioDeEMail.getTlsHabilitado());
+				email.										
+					setFrom(this.remetente).//De
+					addTo(this.destinatarios.toArray(new String[this.destinatarios.size()])).//Para
+					setSubject(this.assunto).//Assunto
+					setMsg(this.mensagem).//Mensagem
+					send();//Enviar				
+			} catch(Exception e){
+				//Tratamento de erro feito provisório
+				System.err.println(MessageFormat.format("Falha no envio de e-mail para {0} o seguinte erro ocorreu: {1}",this.destinatarios, e.getMessage()));
+			}
+			return EmailSender.SUCESSO;
+		}
+
+		@Override
+		public ParaEnviar comA(String mensagem) {
+			this.mensagem = mensagem;
+			return this;
+		}
+
+		@Override
+		public ComAMensagem tratandoDo(String assunto) {
+			this.assunto = assunto;
+			return this;
+		}
+
+		@Override
+		public TratandoDoAssunto para(String destinatario) {
+			if(this.destinatarios == null) this.destinatarios = new ArrayList<>();
+			this.destinatarios.add(destinatario);
+			return this;
+		}
+
+		@Override
+		public TratandoDoAssunto para(Collection<String> destinatarios) {
+			this.destinatarios = destinatarios;
+			return this;
+		}
+
+		@Override
+		public ParaDestinatario de(String remetente) {
+			this.remetente = remetente;
+			return this;
+		}
+
+		
+	}
+	
+	@Override
+	public DeRemetente criarEmail() {
+		Email email = new Email();
+		return email;
+	}
+	
+}

--- a/src/main/resources/email.properties
+++ b/src/main/resources/email.properties
@@ -1,0 +1,12 @@
+remetente=eMail de envio
+senha=senha sem criptografia
+hostSmtp=host do servidor de email
+porta=porta do servidor de email
+tlsHabilitado= se tiver que habilitar o tls deixxar o campo como (sim) caso contratio como (nao)
+
+#Exemplo de configuração
+#remetente=emailDeEnvio@hotmail.com
+#senha=senha
+#hostSmtp=smtp.live.com
+#porta=587
+#tlsHabilitado=sim


### PR DESCRIPTION
Foi criado o envio de e-mail de confirmação quando um usuário se registra em algum evento, foi utilizada a API ApacheCommonsEmail, mas foi feita uma abstração para manter as implementações livres da
tecnologia, alem de criar um código traduzido. Para carregar as informações do servidor de e-mail foi criado o property email.properties. Essa configuração no property foi feita apenas para implementação inicial, podendo ser alterada facilmente a forma como são carregadas as informações do servidor de e-mail, já que o load das informações ficou em uma entidade singleton facilitando o acesso da aplicação a essas informações.
A foi deixada uma mensagem simples de e-mail, já que na atividade nenhuma mensagem era especificada.
Caso vá ser feita uma mensagem mais complexa a API escolhida permite facilmente enviar e-mails com conteudo HTML, facilitando assim  a criação de mensagens mais elaboradas, as a implementação utiliza uma mensagem simples de texto.